### PR TITLE
Fix wrong tailwindcss apply method

### DIFF
--- a/src/WebCamUI.vue
+++ b/src/WebCamUI.vue
@@ -82,7 +82,7 @@
     visibility: hidden;
 }
 .webcam-ui-buttons {
-  @apply flex flex-col justify-center py-2 mx-auto text-center sm:flex-row align-center;
+  @apply flex flex-col justify-center py-2 mx-auto text-center sm:flex-row items-center;
 }
 </style>
 


### PR DESCRIPTION
Method `align-center` doesn't exists on tailwindcss `@apply`, must changed to `items-center`.