### PR TITLE
Shutter effect: Handle element being removed

### DIFF
--- a/src/Webcam.vue
+++ b/src/Webcam.vue
@@ -1,5 +1,6 @@
 
 <template>
+  <div>
     <video
         ref="video"
         class="w-full h-auto"
@@ -13,6 +14,7 @@
         <audio ref="audio" volume="0.5" src="https://www.soundjay.com/mechanical/camera-shutter-click-08.mp3"></audio>
     </div>
     <div ref="shutter" class="shutter"></div>
+  </div>
 </template>
 
 <style scoped>
@@ -34,7 +36,7 @@
   pointer-events: none;
 
   background-color: black;
-  
+
   left:50%;
   top:50%;
   transform: translate(-50%, -50%);
@@ -89,7 +91,7 @@ export default {
             type: String,
             default: '_vwl_device_id'
         },
-        // if should automatically start and select the best device depending to preferCamerasWithLabel and constraints, or selects first device 
+        // if should automatically start and select the best device depending to preferCamerasWithLabel and constraints, or selects first device
         autoStart: {
             type: Boolean,
             default: true
@@ -273,7 +275,7 @@ export default {
                 if (typeof c.video !== 'object' || c.video === null) {
                     c.video = {}
                 }
-                c.video.deviceId = { exact: deviceId } 
+                c.video.deviceId = { exact: deviceId }
             }
             return c;
         },

--- a/src/Webcam.vue
+++ b/src/Webcam.vue
@@ -295,7 +295,7 @@ export default {
                 if (this.shutterEffect) {
                     this.$refs.shutter.classList.add('on');
                     setTimeout(() => {
-                        this.$refs.shutter.classList.remove('on');
+                        this.$refs.shutter && this.$refs.shutter.classList.remove('on');
                     }, 30*2+45);
                 }
                 this.$emit('photoTaken', { blob, image_data_url })


### PR DESCRIPTION
In my app, I remove the webcam element after the picture is taken.

If the webcam element is not found, this.$refs.shutter is missing, causing an exception here. This change just checks to see if the shutter element exists before changing the class list.